### PR TITLE
Remove crow

### DIFF
--- a/sensitive-terms.txt
+++ b/sensitive-terms.txt
@@ -424,7 +424,6 @@ creampie
 crotch
 crotch fiddler
 crotchy
-crow
 cuksuker
 cuksukka
 cum


### PR DESCRIPTION
Remove the word crow from the list. Feels like a major oversight!